### PR TITLE
Add psycopg2-binary dependency and update gitignore for build artifacts

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+build/
+src/backend.egg-info/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "sqlalchemy>=2.0.36",
     "pydantic>=2.9.2",
+    "psycopg2-binary>=2.9.9",
 ]
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Added psycopg2-binary dependency as discussed in Discord for PostgreSQL connection with SQLAlchemy. Also updated .gitignore to prevent build artifacts from being committed.

Changes:
- Add psycopg2-binary>=2.9.9 to dependencies
- Add build/ and src/backend.egg-info/ to .gitignore